### PR TITLE
Fixes modules not found errors

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "external" "this" {
   count = "${length(var.uris)}"
 
-  program = ["python", "-m", "py_getter", "--json", "-"]
+  program = ["python", "${path.module}/py_getter", "--json", "-"]
 
   query = {
     uri     = "${element(var.uris, count.index)}"

--- a/py_getter/__main__.py
+++ b/py_getter/__main__.py
@@ -11,6 +11,16 @@ Why does this file exist, and why __main__? For more info, read:
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals, with_statement)
 
+import os
+import sys
+
+
+parent_dir = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
+
+if parent_dir not in sys.path:
+    sys.path = [parent_dir] + sys.path
+
 from py_getter import cli
 
 if __name__ == "__main__":


### PR DESCRIPTION
Without this patch, using this module as a remote source (git)
results in the error, "No module named py_getter"