### PR TITLE
Uses relpath to avoid differences in absolute paths on different systems

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/examples/ec2/main.tf
+++ b/examples/ec2/main.tf
@@ -49,7 +49,7 @@ resource "aws_security_group" "example" {
   name_prefix = "terraform-external-file-cache-"
   vpc_id      = "${data.aws_vpc.example.id}"
 
-  tags {
+  tags = {
     Name = "terraform-external-file-cache-example"
   }
 
@@ -75,7 +75,7 @@ resource "aws_instance" "example" {
   key_name               = "${aws_key_pair.example.id}"
   vpc_security_group_ids = ["${aws_security_group.example.id}"]
 
-  tags {
+  tags = {
     Name = "terraform-external-file-cache-example"
   }
 }

--- a/py_getter/__init__.py
+++ b/py_getter/__init__.py
@@ -40,7 +40,7 @@ def qualify_uri(uri):
 
 def qualify_path(path):
     """Qualify the destination path."""
-    return os.path.abspath(os.path.expanduser(path))
+    return os.path.relpath(os.path.expanduser(path))
 
 
 def qualify_filename(filename):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 argparse;python_version<"2.7"
+backoff
 boto3
+botocore
 six


### PR DESCRIPTION
For example, the absolute path may include references based on $HOME, or a CI/virtual environment, etc. Differences in the source path from one execution to the next could cause terraform to cycle unnecessarily. One workaround for the cycle is to ignore changes in the source argument, but then problems occur when the source value changes AND the content of the source file changes (because terraform ignores the source change and tries to update using the prior value, which is not valid on the current system).

This patch just uses `relpath` instead of `abspath`, to avoid unnecessary changes in the source path.

Also, due to my current working location, ran into a lot of issues with network connectivity, and had to patch in retries.